### PR TITLE
chore(docs): fix markdownlint issues in PR and Issue templates (MD041…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,9 @@
----
 name: Bug report
 about: Create a report to help us improve
 labels: bug
----
+
+
+# Bug report
 
 ### Describe the bug
 
@@ -14,10 +15,9 @@ Steps to reproduce the behavior:
 ### Screenshots/logs
 
 ### Environment
+
 - OS:
 - Python:
 - Browser:
 
 ### Additional context
-
-

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,9 @@
----
 name: Feature request
 about: Suggest an idea for this project
 labels: enhancement
----
+
+
+# Feature request
 
 ### Problem to solve
 
@@ -11,5 +12,3 @@ labels: enhancement
 ### Alternatives considered
 
 ### Additional context
-
-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Summary
+# Summary
 
 Generated tests and artifacts for: <!-- story id/title -->
 


### PR DESCRIPTION
…, MD012, MD022, MD032)

## Summary

Generated tests and artifacts for: <!-- story id/title -->

## What’s included
- Features: <!-- list -->
- Step definitions: <!-- list -->
- Tests: <!-- list -->
- Artifacts: requirement_graph.json, test_cases.json

## Evidence
- Local run mode: `mock|stub|real`
- All tests: PASSED
- Allure report: <!-- link -->

## Checks
- [x] Reuse-first verified (no duplicates)
- [x] Docs-lint passes locally
- [x] Self-heal suggestions reviewed (if any)

## Notes


